### PR TITLE
set nthreads dynamically

### DIFF
--- a/bin/config_example.yaml
+++ b/bin/config_example.yaml
@@ -25,7 +25,6 @@ output:
 algorithm:
   name: MultiGridReconstruction                                                 # name of reconstruction algorithm (Julian's IterativeFFTReconstruction, Martin's MultiGridReconstruction)
   convention: RecSym                                                            # RecSym = RSD-shifted randoms or RecIso = only data RSD-shifted
-  nthreads: 4                                                                   # number of OpenMP threads
   los: 'local'                                                                  # line-of-sight can be 'local' (default) or an axis ('x', 'y', 'z') or a 3-vector.
   # other algorithm-related parameters
 

--- a/bin/pyrecon
+++ b/bin/pyrecon
@@ -116,8 +116,9 @@ def main(args=None):
     config_cosmo = {name:value for name,value in config['cosmology'].items() if name in ['f','bias']}
     config_cosmo['los'] = config['algorithm'].pop('los',None)
     convention = config['algorithm'].pop('convention').lower()
-    nthreads = multiprocessing.cpu_count()
-    #nthreads = config['algorithm'].pop('nthreads',None)
+    nthreads = config['algorithm'].pop('nthreads',None)
+    if nthreads is None:
+        nthreads = multiprocessing.cpu_count()
     allowed_conventions = ['recsym','reciso']
     if not convention in allowed_conventions:
         raise ConfigError('Unknown convention {}. Choices are {}'.format(convention, allowed_conventions))

--- a/bin/pyrecon
+++ b/bin/pyrecon
@@ -11,6 +11,7 @@ import logging
 import datetime
 import argparse
 import re
+import multiprocessing
 
 import numpy as np
 import yaml
@@ -115,7 +116,8 @@ def main(args=None):
     config_cosmo = {name:value for name,value in config['cosmology'].items() if name in ['f','bias']}
     config_cosmo['los'] = config['algorithm'].pop('los',None)
     convention = config['algorithm'].pop('convention').lower()
-    nthreads = config['algorithm'].pop('nthreads',None)
+    nthreads = multiprocessing.cpu_count()
+    #nthreads = config['algorithm'].pop('nthreads',None)
     allowed_conventions = ['recsym','reciso']
     if not convention in allowed_conventions:
         raise ConfigError('Unknown convention {}. Choices are {}'.format(convention, allowed_conventions))


### PR DESCRIPTION
In the standalone `pyrecon` implementation, set `nthreads` based on the number of cpus available (using `multiprocessing.cpu_count()`) instead of based on user input.

When working on slurm or other HPC systems, the user might want to request a different number of cpus for different runs by editing the job submission script, depending on resources available. This way they don't need to also edit the config yaml file to keep them in sync.