### PR TITLE
Wrapping for periodic boundary conditions

### DIFF
--- a/bin/config_example.yaml
+++ b/bin/config_example.yaml
@@ -45,3 +45,4 @@ mesh:
   dtype: f4                                                                     # mesh data-type for f4 (float32) or f8 (float64)
   fft_engine: 'fftw'                                                            # FFT engine, either 'numpy' or 'fftw' (recommended)
   fft_plan: 'estimate'                                                          # FFT planning for FFTW engine
+  wrap: False                                                                   # whether to wrap positions using periodic boundary conditions over the box

--- a/bin/pyrecon
+++ b/bin/pyrecon
@@ -345,16 +345,10 @@ def main(args=None, **input_config):
     field = 'rsd' if convention == 'rsd' else 'disp+rsd'
     if type(recon) is IterativeFFTParticleReconstruction:
         positions_rec['data'] = positions['data'] - recon.read_shifts('data', field=field)
-        if wrap:
-            boxsize = recon.mesh_psi[0].boxsize
-            offset = recon.mesh_psi[0].offset
-            positions_rec['data'] = (positions_rec['data'] - offset) % boxsize + offset
     else:
         positions_rec['data'] = positions['data'] - recon.read_shifts(positions['data'], field=field)
-        if wrap:
-            boxsize = recon.mesh_delta.boxsize
-            offset = recon.mesh_delta.offset
-            positions_rec['data'] = (positions_rec['data'] - offset) % boxsize + offset
+    if wrap:
+        positions_rec['data'] = (positions_rec['data'] - recon.offset) % recon.boxsize + recon.offset
     if 'randoms' in output_fns:
         # RSD removal only: no effect on the randoms
         if convention == 'rsd':
@@ -364,8 +358,10 @@ def main(args=None, **input_config):
             # convention == reciso: move randoms by Zeldovich displacement
             field = 'disp+rsd' if convention == 'recsym' else 'disp'
             positions_rec['randoms'] = positions['randoms'] - recon.read_shifts(positions['randoms'], field=field)
-            if wrap:
-                positions_rec['randoms'] = (positions_rec['randoms'] - offset) % boxsize + offset
+        if wrap:
+            # note that output reconstructed random positions will be wrapped so may differ from input
+            # positions even if convention is 'rsd' if input positions are not wrapped 
+            positions_rec['randoms'] = (positions_rec['randoms'] - recon.offset) % recon.boxsize + recon.offset
 
     # Now dump reconstructed catalogs to disk
     for name in output_fns:

--- a/bin/pyrecon
+++ b/bin/pyrecon
@@ -341,11 +341,20 @@ def main(args=None, **input_config):
 
     # Read shifts
     positions_rec = {}
+    wrap = config['mesh'].get('wrap', False)
     field = 'rsd' if convention == 'rsd' else 'disp+rsd'
     if type(recon) is IterativeFFTParticleReconstruction:
         positions_rec['data'] = positions['data'] - recon.read_shifts('data', field=field)
+        if wrap:
+            boxsize = recon.mesh_psi[0].boxsize
+            offset = recon.mesh_psi[0].offset
+            positions_rec['data'] = (positions_rec['data'] - offset) % boxsize + offset
     else:
         positions_rec['data'] = positions['data'] - recon.read_shifts(positions['data'], field=field)
+        if wrap:
+            boxsize = recon.mesh_delta.boxsize
+            offset = recon.mesh_delta.offset
+            positions_rec['data'] = (positions_rec['data'] - offset) % boxsize + offset
     if 'randoms' in output_fns:
         # RSD removal only: no effect on the randoms
         if convention == 'rsd':
@@ -355,6 +364,8 @@ def main(args=None, **input_config):
             # convention == reciso: move randoms by Zeldovich displacement
             field = 'disp+rsd' if convention == 'recsym' else 'disp'
             positions_rec['randoms'] = positions['randoms'] - recon.read_shifts(positions['randoms'], field=field)
+            if wrap:
+                positions_rec['randoms'] = (positions_rec['randoms'] - offset) % boxsize + offset
 
     # Now dump reconstructed catalogs to disk
     for name in output_fns:

--- a/pyrecon/iterative_fft_particle.py
+++ b/pyrecon/iterative_fft_particle.py
@@ -20,7 +20,7 @@ class OriginalIterativeFFTParticleReconstruction(BaseReconstruction):
         See :meth:`BaseReconstruction.assign_data` for parameters.
         """
         if self.wrap:
-            positions = (positions - self.mesh_randoms.offset) % self.mesh_randoms.boxsize + self.mesh_randoms.offset
+            positions = (positions - self.offset) % self.boxsize + self.offset
         if weights is None:
             weights = np.ones_like(positions,shape=(len(positions),))
         if self.mesh_data.value is None:
@@ -38,7 +38,7 @@ class OriginalIterativeFFTParticleReconstruction(BaseReconstruction):
         See :meth:`BaseReconstruction.assign_randoms` for parameters.
         """
         if self.wrap:
-            positions = (positions - self.mesh_randoms.offset) % self.mesh_randoms.boxsize + self.mesh_randoms.offset
+            positions = (positions - self.offset) % self.boxsize + self.offset
         if weights is None:
             weights = np.ones_like(positions,shape=(len(positions),))
         if self.mesh_randoms.value is None:
@@ -205,13 +205,13 @@ class OriginalIterativeFFTParticleReconstruction(BaseReconstruction):
             return shifts
 
         # check input positions
-        diff = positions - self.mesh_psi[0].offset
-        if np.any((diff < 0) | (diff > self.mesh_psi[0].boxsize - self.mesh_psi[0].cellsize)):
+        diff = positions - self.offset
+        if np.any((diff < 0) | (diff > self.boxsize - self.cellsize)):
             if self.wrap:
-                positions = diff % self.mesh_psi[0].boxsize + self.mesh_psi[0].offset
+                positions = diff % self.boxsize + self.offset
             else:
                 self.log_warning('Some input particle positions are out of bounds')
-            
+
         shifts = read_cic(positions)
 
         if field == 'disp':

--- a/pyrecon/multigrid.py
+++ b/pyrecon/multigrid.py
@@ -125,6 +125,14 @@ class OriginalMultiGridReconstruction(BaseReconstruction):
         Read displacement at input positions by deriving the computed displacement potential :attr:`mesh_phi` (finite difference scheme).
         See :meth:`BaseReconstruction.read_shifts` for input parameters.
         """
+        # check input positions
+        diff = positions - self.offset
+        if np.any((diff < 0) | (diff > self.boxsize - self.cellsize)):
+            if self.wrap:
+                positions = diff % self.boxsize + self.offset
+            else:
+                self.log_warning('Some input particle positions are out of bounds')
+                
         field = field.lower()
         allowed_fields = ['disp', 'rsd', 'disp+rsd']
         if field not in allowed_fields:

--- a/pyrecon/recon.py
+++ b/pyrecon/recon.py
@@ -92,6 +92,10 @@ class BaseReconstruction(BaseClass):
         self.wrap = wrap
         self.mesh_data = RealMesh(**kwargs)
         self.mesh_randoms = RealMesh(**kwargs)
+        # record mesh boxsize, cellsize and offset for later use when the meshes themselves get deleted
+        self.boxsize = self.mesh_randoms.boxsize
+        self.offset = self.mesh_randoms.offset
+        self.cellsize = self.mesh_randoms.cellsize
         self.set_los(los)
         self.log_info('Using mesh {}.'.format(self.mesh_data))
         kwargs = {}
@@ -165,13 +169,13 @@ class BaseReconstruction(BaseClass):
             Weights; default to 1.
         """
         if self.wrap:
-            positions = (positions - self.mesh_randoms.offset) % self.mesh_randoms.boxsize + self.mesh_randoms.offset
+            positions = (positions - self.offset) % self.boxsize + self.offset
         self.mesh_data.assign_cic(positions, weights=weights)
 
     def assign_randoms(self, positions, weights=None):
         """Same as :meth:`assign_data`, but for random objects."""
         if self.wrap:
-            positions = (positions - self.mesh_randoms.offset) % self.mesh_randoms.boxsize + self.mesh_randoms.offset
+            positions = (positions - self.offset) % self.boxsize + self.offset
         self.mesh_randoms.assign_cic(positions, weights=weights)
 
     @property
@@ -260,10 +264,10 @@ class BaseReconstruction(BaseClass):
             Displacements.
         """
         # check input positions
-        diff = positions - self.mesh_delta.offset
-        if np.any((diff < 0) | (diff > self.mesh_delta.boxsize - self.mesh_delta.cellsize)):
+        diff = positions - self.offset
+        if np.any((diff < 0) | (diff > self.boxsize - self.cellsize)):
             if self.wrap:
-                positions = diff % self.mesh_delta.boxsize + self.mesh_delta.offset
+                positions = diff % self.boxsize + self.offset
             else:
                 self.log_warning('Some input particle positions are out of bounds')
 

--- a/pyrecon/tests/test_iterative_fft.py
+++ b/pyrecon/tests/test_iterative_fft.py
@@ -66,7 +66,7 @@ def test_iterative_fft_wrap():
         # set one of the random positions to be outside the fiducial box by hand
         randoms['Position'][-1] = np.array([0, 0, 0]) - 1
         randoms['Position'] += boxcenter
-        recon = pyrecon.IterativeFFTReconstruction(f=0.8, bias=2, los='z', boxsize=boxsize, boxcenter=boxcenter, nmesh=64, wrap=True)
+        recon = IterativeFFTReconstruction(f=0.8, bias=2, los='z', boxsize=boxsize, boxcenter=boxcenter, nmesh=64, wrap=True)
         # following steps should run without error if wrapping is correctly implemented
         recon.assign_data(data['Position'],data['Weight'])
         recon.assign_randoms(randoms['Position'],randoms['Weight'])

--- a/pyrecon/tests/test_iterative_fft_particle.py
+++ b/pyrecon/tests/test_iterative_fft_particle.py
@@ -69,6 +69,32 @@ def test_mem():
         recon.run()
         mem('recon') # 3 meshes
 
+def test_iterative_fft_particle_wrap():
+    size = 100000
+    boxsize = 1000
+    for origin in [-500, 0, 500]:
+        boxcenter = boxsize/2 + origin
+        data = get_random_catalog(size, boxsize, seed=42)
+        # set one of the data positions to be outside the fiducial box by hand
+        data['Position'][-1] = np.array([boxsize, boxsize, boxsize]) + 1
+        data['Position'] += boxcenter
+        randoms = get_random_catalog(size, boxsize, seed=42)
+        # set one of the random positions to be outside the fiducial box by hand
+        randoms['Position'][-1] = np.array([0, 0, 0]) - 1
+        randoms['Position'] += boxcenter
+        recon = pyrecon.IterativeFFTParticleReconstruction(f=0.8, bias=2, los='z', boxsize=boxsize, boxcenter=boxcenter, nmesh=64, wrap=True)
+        # following steps should run without error if wrapping is correctly implemented
+        recon.assign_data(data['Position'],data['Weight'])
+        recon.assign_randoms(randoms['Position'],randoms['Weight'])
+        recon.set_density_contrast()
+        recon.run()
+
+        # following steps test the implementation coded into standalone pyrecon code
+        for field in ['rsd', 'disp', 'disp+rsd']:
+            shifts = recon.read_shifts('data', field=field)
+            diff = data['Position'] - shifts
+            positions_rec = (diff - recon.offset) % recon.boxsize + recon.offset
+            assert np.all(positions_rec <= origin + boxsize) and np.all(positions_rec >= origin)
 
 def test_los():
     boxsize = 1000.

--- a/pyrecon/tests/test_iterative_fft_particle.py
+++ b/pyrecon/tests/test_iterative_fft_particle.py
@@ -82,7 +82,7 @@ def test_iterative_fft_particle_wrap():
         # set one of the random positions to be outside the fiducial box by hand
         randoms['Position'][-1] = np.array([0, 0, 0]) - 1
         randoms['Position'] += boxcenter
-        recon = pyrecon.IterativeFFTParticleReconstruction(f=0.8, bias=2, los='z', boxsize=boxsize, boxcenter=boxcenter, nmesh=64, wrap=True)
+        recon = IterativeFFTParticleReconstruction(f=0.8, bias=2, los='z', boxsize=boxsize, boxcenter=boxcenter, nmesh=64, wrap=True)
         # following steps should run without error if wrapping is correctly implemented
         recon.assign_data(data['Position'],data['Weight'])
         recon.assign_randoms(randoms['Position'],randoms['Weight'])

--- a/pyrecon/tests/test_multigrid.py
+++ b/pyrecon/tests/test_multigrid.py
@@ -41,6 +41,32 @@ def test_no_nrandoms():
     #recon.run()
     assert np.all(np.abs(recon.read_shifts(data['Position'])) < 2.)
 
+def test_multigrid_wrap():
+    size = 100000
+    boxsize = 1000
+    for origin in [-500, 0, 500]:
+        boxcenter = boxsize/2 + origin
+        data = get_random_catalog(size, boxsize, seed=42)
+        # set one of the data positions to be outside the fiducial box by hand
+        data['Position'][-1] = np.array([boxsize, boxsize, boxsize]) + 1
+        data['Position'] += boxcenter
+        randoms = get_random_catalog(size, boxsize, seed=42)
+        # set one of the random positions to be outside the fiducial box by hand
+        randoms['Position'][-1] = np.array([0, 0, 0]) - 1
+        randoms['Position'] += boxcenter
+        recon = pyrecon.MultiGridReconstruction(f=0.8, bias=2, los='z', boxsize=boxsize, boxcenter=boxcenter, nmesh=64, wrap=True)
+        # following steps should run without error if wrapping is correctly implemented
+        recon.assign_data(data['Position'],data['Weight'])
+        recon.assign_randoms(randoms['Position'],randoms['Weight'])
+        recon.set_density_contrast()
+        recon.run()
+
+        # following steps test the implementation coded into standalone pyrecon code
+        for field in ['rsd', 'disp', 'disp+rsd']:
+            shifts = recon.read_shifts(data['Position'], field=field)
+            diff = data['Position'] - shifts
+            positions_rec = (diff - recon.offset) % recon.boxsize + recon.offset
+            assert np.all(positions_rec <= origin + boxsize) and np.all(positions_rec >= origin)
 
 def test_dtype():
     # ran_min threshold in set_density_contrast() may not mask exactly the same number of cells in f4 and f8 cases, hence big difference in the end

--- a/pyrecon/tests/test_multigrid.py
+++ b/pyrecon/tests/test_multigrid.py
@@ -54,7 +54,7 @@ def test_multigrid_wrap():
         # set one of the random positions to be outside the fiducial box by hand
         randoms['Position'][-1] = np.array([0, 0, 0]) - 1
         randoms['Position'] += boxcenter
-        recon = pyrecon.MultiGridReconstruction(f=0.8, bias=2, los='z', boxsize=boxsize, boxcenter=boxcenter, nmesh=64, wrap=True)
+        recon = MultiGridReconstruction(f=0.8, bias=2, los='z', boxsize=boxsize, boxcenter=boxcenter, nmesh=64, wrap=True)
         # following steps should run without error if wrapping is correctly implemented
         recon.assign_data(data['Position'],data['Weight'])
         recon.assign_randoms(randoms['Position'],randoms['Weight'])

--- a/pyrecon/tests/test_plane_parallel_fft.py
+++ b/pyrecon/tests/test_plane_parallel_fft.py
@@ -66,7 +66,7 @@ def test_plane_parallel_fft_wrap():
         # set one of the random positions to be outside the fiducial box by hand
         randoms['Position'][-1] = np.array([0, 0, 0]) - 1
         randoms['Position'] += boxcenter
-        recon = pyrecon.PlaneParallelFFTReconstruction(f=0.8, bias=2, los='z', boxsize=boxsize, boxcenter=boxcenter, nmesh=64, wrap=True)
+        recon = PlaneParallelFFTReconstruction(f=0.8, bias=2, los='z', boxsize=boxsize, boxcenter=boxcenter, nmesh=64, wrap=True)
         # following steps should run without error if wrapping is correctly implemented
         recon.assign_data(data['Position'],data['Weight'])
         recon.assign_randoms(randoms['Position'],randoms['Weight'])

--- a/pyrecon/tests/test_plane_parallel_fft.py
+++ b/pyrecon/tests/test_plane_parallel_fft.py
@@ -53,6 +53,32 @@ def test_mem():
         recon.run()
         mem('recon') # 3 meshes
 
+def test_plane_parallel_fft_wrap():
+    size = 100000
+    boxsize = 1000
+    for origin in [-500, 0, 500]:
+        boxcenter = boxsize/2 + origin
+        data = get_random_catalog(size, boxsize, seed=42)
+        # set one of the data positions to be outside the fiducial box by hand
+        data['Position'][-1] = np.array([boxsize, boxsize, boxsize]) + 1
+        data['Position'] += boxcenter
+        randoms = get_random_catalog(size, boxsize, seed=42)
+        # set one of the random positions to be outside the fiducial box by hand
+        randoms['Position'][-1] = np.array([0, 0, 0]) - 1
+        randoms['Position'] += boxcenter
+        recon = pyrecon.PlaneParallelFFTReconstruction(f=0.8, bias=2, los='z', boxsize=boxsize, boxcenter=boxcenter, nmesh=64, wrap=True)
+        # following steps should run without error if wrapping is correctly implemented
+        recon.assign_data(data['Position'],data['Weight'])
+        recon.assign_randoms(randoms['Position'],randoms['Weight'])
+        recon.set_density_contrast()
+        recon.run()
+
+        # following steps test the implementation coded into standalone pyrecon code
+        for field in ['rsd', 'disp', 'disp+rsd']:
+            shifts = recon.read_shifts(data['Position'], field=field)
+            diff = data['Position'] - shifts
+            positions_rec = (diff - recon.offset) % recon.boxsize + recon.offset
+            assert np.all(positions_rec <= origin + boxsize) and np.all(positions_rec >= origin)
 
 def test_plane_parallel_fft(data_fn, randoms_fn):
     boxsize = 1200.


### PR DESCRIPTION
I have added a new argument `wrap` to be provided when initialising the reconstruction instance (addressing #4). If it is True, periodic boundary conditions are assumed with the mesh `boxsize` and particle positions are wrapped around to remain inside the box. Input data positions get wrapped too (and input randoms if provided, though when wrapping is being used data will generally come from a simulation with uniform selection function so randoms are not necessary).

This removes a possible point of failure where input data contain positions that lie exactly on a box edge. Wrapping is checked and maintained throughout the reconstruction process. I have changed the standalone `pyrecon` code to accept `wrap` as a mesh input from the config file and to consistently wrap the output reconstructed positions as well. 