### PR TITLE
added save wisdom functionality

### DIFF
--- a/bin/config_example.yaml
+++ b/bin/config_example.yaml
@@ -46,3 +46,4 @@ mesh:
   fft_engine: 'fftw'                                                            # FFT engine, either 'numpy' or 'fftw' (recommended)
   fft_plan: 'estimate'                                                          # FFT planning for FFTW engine
   wrap: False                                                                   # whether to wrap positions using periodic boundary conditions over the box
+  fft_wisdom:                                                                   # wisdom for 'fftw' FFT engine (optional)

--- a/pyrecon/mesh.py
+++ b/pyrecon/mesh.py
@@ -987,7 +987,7 @@ class FFTWEngine(BaseFFTEngine):
 
         wisdom : string, tuple, default=None
             :mod:`pyfftw` wisdom, used to accelerate further FFTs.
-            If a string, should be a path to the save FFT wisdom (with :func:`numpy.save`).
+            If a string, should be a path to previously saved FFT wisdom (with :func:`numpy.save`).
             If a tuple, directly corresponds to the wisdom.
 
         plan : string, default='measure'
@@ -1008,7 +1008,10 @@ class FFTWEngine(BaseFFTEngine):
         plan = 'FFTW_{}'.format(plan.upper())
 
         if isinstance(wisdom, str):
-            wisdom = tuple(np.load(wisdom))
+            if os.path.isfile(wisdom):
+                wisdom = tuple(np.load(wisdom))
+            else:
+                wisdom = None
         if wisdom is not None:
             pyfftw.import_wisdom(wisdom)
         else:
@@ -1024,6 +1027,8 @@ class FFTWEngine(BaseFFTEngine):
         self.fftw_backward_object = pyfftw.FFTW(fftw_fk, fftw_f, axes=range(self.ndim), direction='FFTW_BACKWARD', flags=self.flags, threads=self.nthreads)
         # We delete these instances to save memory, see note above
         self.fftw_forward_object, self.fftw_backward_object = None, None
+        # allow the wisdom to be accessed from outside
+        self.fft_wisdom = pyfftw.export_wisdom()
 
     def forward(self, fun):
         """Return forward transform of ``fun``."""

--- a/pyrecon/tests/test_iterative_fft.py
+++ b/pyrecon/tests/test_iterative_fft.py
@@ -53,6 +53,20 @@ def test_mem():
         recon.run()
         mem('recon') # 3 meshes
 
+def test_wisdom():
+    recon = IterativeFFTReconstruction(f=0.8, bias=2, los='z', boxsize=1000, boxcenter=500, nmesh=64, fft_engine='fftw', fft_plan='measure')
+    # wisdom created and accessible
+    assert recon.wisdom
+    default_wisdom_fn = os.path.join(os.getcwd(), f'wisdom.{recon.mesh_data.nmesh[0]}.{recon.mesh_data.nthreads}.npy')
+    print(default_wisdom_fn)
+    # wisdom was written to default wisdom file
+    assert os.path.isfile(default_wisdom_fn)
+    new_wisdom_fn = 'new_wisdomfile.npy'
+    recon = IterativeFFTReconstruction(f=0.8, bias=2, los='z', boxsize=1000, boxcenter=500, nmesh=64, fft_engine='fftw', fft_plan='measure', fft_wisdom=new_wisdom_fn)
+    # wisdom written to custom file
+    assert os.path.isfile(new_wisdom_fn)
+    # wisdom written to both files is the same
+    assert tuple(np.load(default_wisdom_fn)) == tuple(np.load(new_wisdom_fn))
 
 def test_iterative_fft_wrap():
     size = 100000

--- a/pyrecon/tests/test_iterative_fft_particle.py
+++ b/pyrecon/tests/test_iterative_fft_particle.py
@@ -71,6 +71,20 @@ def test_mem():
         recon.run()
         mem('recon') # 3 meshes
 
+def test_wisdom():
+    recon = IterativeFFTParticleReconstruction(f=0.8, bias=2, los='z', boxsize=1000, boxcenter=500, nmesh=64, fft_engine='fftw', fft_plan='measure')
+    # wisdom created and accessible
+    assert recon.wisdom
+    default_wisdom_fn = os.path.join(os.getcwd(), f'wisdom.{recon.mesh_data.nmesh[0]}.{recon.mesh_data.nthreads}.npy')
+    print(default_wisdom_fn)
+    # wisdom was written to default wisdom file
+    assert os.path.isfile(default_wisdom_fn)
+    new_wisdom_fn = 'new_wisdomfile.npy'
+    recon = IterativeFFTParticleReconstruction(f=0.8, bias=2, los='z', boxsize=1000, boxcenter=500, nmesh=64, fft_engine='fftw', fft_plan='measure', fft_wisdom=new_wisdom_fn)
+    # wisdom written to custom file
+    assert os.path.isfile(new_wisdom_fn)
+    # wisdom written to both files is the same
+    assert tuple(np.load(default_wisdom_fn)) == tuple(np.load(new_wisdom_fn))
 
 def test_iterative_fft_particle_wrap():
     size = 100000


### PR DESCRIPTION
I have added some features around the wisdom for the `fftw` FFT engine (addressing #5). The `FFTWEngine` class now checks that the input wisdom string corresponds to an existing file before trying to load it. This allows `BaseReconstruction` class to pass a default wisdom filename as argument during initialisation if none is provided. Except in the case that the wisdom input is directly a tuple, the wisdom is always saved to file after creation, either in the file location provided as input, or in a default location if no input is provided. The motivation here is to provide a way to speed up batch runs from the command line without requiring user input for the wisdom, similar to what was achieved in Julian's code.