### PR TITLE
check for out-of-bounds in python rather than in C

### DIFF
--- a/nb/e2e_examples.ipynb
+++ b/nb/e2e_examples.ipynb
@@ -177,7 +177,7 @@
     "                        interlacing=2, ells=(0, 2, 4), los=los, edges=kedges, position_type='pos').poles\n",
     "\n",
     "poles_recon = CatalogFFTPower(data_positions1=data['Position_rec'], shifted_positions1=randoms['Position_rec'],\n",
-    "                            boxsize=boxsize, boxcenter=boxcenter, nmesh=nmesh, resampler='cic', interlacing=2, ells=(0, 2, 4), los=los, edges=kedges, position_type='pos').poles\n",
+    "                              boxsize=boxsize, boxcenter=boxcenter, nmesh=nmesh, resampler='cic', interlacing=2, ells=(0, 2, 4), los=los, edges=kedges, position_type='pos').poles\n",
     "\n",
     "ax = plt.gca()\n",
     "for ill, ell in enumerate(poles.ells):\n",

--- a/pyrecon/mesh.py
+++ b/pyrecon/mesh.py
@@ -531,7 +531,12 @@ class RealMesh(BaseMesh):
         """
         size = len(positions)
         if weights is None: weights = np.ones_like(positions,shape=size,dtype=self._type_float)
-        if wrap: positions = self.info.wrap(positions)
+        if wrap:
+            positions = self.info.wrap(positions)
+        else:
+            low, high = self.boxcenter - self.boxsize/2., self.boxcenter + self.boxsize/2.
+            if not np.all((positions >= low) & (positions <= high)):
+                raise MeshError('positions not in box range {} - {}'.format(low, high))
         positions = ((positions - self.boxcenter)/self.boxsize + 0.5)*self.nmesh
         positions = positions.astype(self._type_float, copy=False).ravel(order='C')
         weights = weights.astype(self._type_float, copy=False).ravel(order='C')
@@ -567,7 +572,12 @@ class RealMesh(BaseMesh):
         """
         size = len(positions)
         dtype = positions.dtype
-        if wrap: positions = self.info.wrap(positions)
+        if wrap:
+            positions = self.info.wrap(positions)
+        else:
+            low, high = self.boxcenter - self.boxsize/2., self.boxcenter + self.boxsize/2.
+            if not np.all((positions >= low) & (positions <= high)):
+                raise MeshError('positions not in box range {} - {}'.format(low, high))
         positions = ((positions - self.boxcenter)/self.boxsize + 0.5)*self.nmesh
         positions = positions.astype(self._type_float,copy=False).ravel(order='C')
         values = np.empty_like(positions,shape=size,order='C')
@@ -601,7 +611,12 @@ class RealMesh(BaseMesh):
         """
         size = len(positions)
         dtype = positions.dtype
-        if wrap: positions = self.info.wrap(positions)
+        if wrap:
+            positions = self.info.wrap(positions)
+        else:
+            low, high = self.boxcenter - self.boxsize/2., self.boxcenter + self.boxsize/2.
+            if not np.all((positions >= low) & (positions <= high)):
+                raise MeshError('positions not in box range {} - {}'.format(low, high))
         positions = ((positions - self.boxcenter)/self.boxsize + 0.5)*self.nmesh
         positions = positions.astype(self._type_float,copy=False).ravel(order='C')
         values = np.empty_like(positions,order='C')

--- a/src/mesh.c
+++ b/src/mesh.c
@@ -32,13 +32,16 @@ int assign_cic(FLOAT* mesh, const int* nmesh, const FLOAT* positions, const FLOA
   for (size_t ii=0; ii<npositions; ii++) {
     const FLOAT weight = weights[ii];
     const FLOAT *pos = &(positions[ii*NDIM]);
-    int ix0 = (int) pos[0];
-    int iy0 = (int) pos[1];
-    int iz0 = (int) pos[2];
-    if (ix0<0 || ix0>=nmesh[0] || iy0<0 || iy0>=nmesh[1] || iz0<0 || iz0>=nmesh[2]) {
-      printf("Index out of range: (ix,iy,iz) = (%d,%d,%d) for (%.3f,%.3f,%.3f)\n",ix0,iy0,iz0,pos[0],pos[1],pos[2]);
-      return -1;
-    }
+    int ix0 = ((int) pos[0]) % nmesh[0];
+    int iy0 = ((int) pos[1]) % nmesh[1];
+    int iz0 = ((int) pos[2]) % nmesh[2];
+    //int ix0 = (int) pos[0];
+    //int iy0 = (int) pos[1];
+    //int iz0 = (int) pos[2];
+    //if (ix0<0 || ix0>=nmesh[0] || iy0<0 || iy0>=nmesh[1] || iz0<0 || iz0>=nmesh[2]) {
+    //  printf("Index out of range: (ix,iy,iz) = (%d,%d,%d) for (%.3f,%.3f,%.3f)\n",ix0,iy0,iz0,pos[0],pos[1],pos[2]);
+    //  return -1;
+    //}
     FLOAT dx = pos[0] - ix0;
     FLOAT dy = pos[1] - iy0;
     FLOAT dz = pos[2] - iz0;
@@ -200,14 +203,17 @@ int read_finite_difference_cic(const FLOAT* mesh, const int* nmesh, const FLOAT*
     // see what's going on and to encourage the compiler to optimize
     // and vectorize the code as much as possible.
     const FLOAT *pos = &(positions[ii*NDIM]);
-    int ix0 = (int) pos[0];
-    int iy0 = (int) pos[1];
-    int iz0 = (int) pos[2];
-    if (ix0<0 || ix0>=nmesh[0] || iy0<0 || iy0>=nmesh[1] || iz0<0 || iz0>=nmesh[2]) {
-      printf("Index out of range: (ix,iy,iz) = (%d,%d,%d) for (%.3f,%.3f,%.3f)\n",ix0,iy0,iz0,pos[0],pos[1],pos[2]);
-      flag = 1;
-      continue;
-    }
+    int ix0 = ((int) pos[0]) % nmesh[0];
+    int iy0 = ((int) pos[1]) % nmesh[1];
+    int iz0 = ((int) pos[2]) % nmesh[2];
+    //int ix0 = (int) pos[0];
+    //int iy0 = (int) pos[1];
+    //int iz0 = (int) pos[2];
+    //if (ix0<0 || ix0>=nmesh[0] || iy0<0 || iy0>=nmesh[1] || iz0<0 || iz0>=nmesh[2]) {
+    //  printf("Index out of range: (ix,iy,iz) = (%d,%d,%d) for (%.3f,%.3f,%.3f)\n",ix0,iy0,iz0,pos[0],pos[1],pos[2]);
+    //  flag = 1;
+    //  continue;
+    //}
     FLOAT dx = pos[0] - ix0;
     FLOAT dy = pos[1] - iy0;
     FLOAT dz = pos[2] - iz0;
@@ -277,14 +283,17 @@ int read_cic(const FLOAT* mesh, const int* nmesh, const FLOAT* positions, FLOAT*
   for (size_t ii=0; ii<npositions; ii++) {
     if (flag) continue;
     const FLOAT *pos = &(positions[ii*NDIM]);
-    int ix0 = (int) pos[0];
-    int iy0 = (int) pos[1];
-    int iz0 = (int) pos[2];
-    if (ix0<0 || ix0>=nmesh[0] || iy0<0 || iy0>=nmesh[1] || iz0<0 || iz0>=nmesh[2]) {
-      printf("Index out of range: (ix,iy,iz) = (%d,%d,%d) for (%.3f,%.3f,%.3f)\n",ix0,iy0,iz0,pos[0],pos[1],pos[2]);
-      flag = 1;
-      continue;
-    }
+    int ix0 = ((int) pos[0]) % nmesh[0];
+    int iy0 = ((int) pos[1]) % nmesh[1];
+    int iz0 = ((int) pos[2]) % nmesh[2];
+    //int ix0 = (int) pos[0];
+    //int iy0 = (int) pos[1];
+    //int iz0 = (int) pos[2];
+    //if (ix0<0 || ix0>=nmesh[0] || iy0<0 || iy0>=nmesh[1] || iz0<0 || iz0>=nmesh[2]) {
+    //  printf("Index out of range: (ix,iy,iz) = (%d,%d,%d) for (%.3f,%.3f,%.3f)\n",ix0,iy0,iz0,pos[0],pos[1],pos[2]);
+    //  flag = 1;
+    //  continue;
+    //}
     FLOAT dx = pos[0] - ix0;
     FLOAT dy = pos[1] - iy0;
     FLOAT dz = pos[2] - iz0;


### PR DESCRIPTION
Checks are performed on the python side for out-of-bounds positions (only if wrap is False).
On the C-side, positions are wrapped inside the box.
Should avoid errors due to numerical rounding.