### PR TITLE
allow array boxsize from positions

### DIFF
--- a/pyrecon/mesh.py
+++ b/pyrecon/mesh.py
@@ -397,7 +397,7 @@ class MeshInfo(BaseClass):
                 if cellsize is not None and nmesh is not None:
                     boxsize = nmesh * cellsize
                 else:
-                    boxsize = delta.max() * boxpad
+                    boxsize = delta * boxpad
             if (boxsize < delta).any(): raise MeshError('boxsize too small to contain all data')
 
         boxsize = _make_array(boxsize, self.ndim, dtype='f8')


### PR DESCRIPTION
Set boxsize to be an array when it is determined from positions, to allow for automatic creation of non-cubic boxes. Non-cubic boxes are allowed when specified by the user, but currently when automatically determining boxsize from positions the box is taken to be a cube, which is rather wasteful for most survey geometries.