### PR TITLE
fixed issue in set_los to take 3-vector los

### DIFF
--- a/pyrecon/recon.py
+++ b/pyrecon/recon.py
@@ -397,8 +397,9 @@ class BaseReconstruction(BaseClass):
             Else, may be 'x', 'y' or 'z', for one of the Cartesian axes.
             Else, a 3-vector.
         """
-        if los in [None, 'local']:
-            self.los = None
+        if not isinstance(los, (list, np.ndarray)):
+            if los in [None, 'local']:
+                self.los = None
         else:
             if isinstance(los, str):
                 los = 'xyz'.index(los)

--- a/pyrecon/recon.py
+++ b/pyrecon/recon.py
@@ -397,9 +397,10 @@ class BaseReconstruction(BaseClass):
             Else, may be 'x', 'y' or 'z', for one of the Cartesian axes.
             Else, a 3-vector.
         """
-        if not isinstance(los, (list, np.ndarray)):
-            if los in [None, 'local']:
-                self.los = None
+
+        if los is None or (isinstance(los, str) and los == 'local'):
+            self.los = None
+
         else:
             if isinstance(los, str):
                 los = 'xyz'.index(los)


### PR DESCRIPTION
Hi Arnaud,

I'm running pyrecon with a customized LOS direction (global, but not x, y, z, or even if it's x, y, or z, I give a 3-vector np.array([1,0,0])). It hit an error inside the `set_los` function. I think it's because my `los` is an array having three components. 

Error message I got: 

> File "/global/common/software/desi/users/adematti/perlmutter/cosmodesiconda/20240118-1.0.0/code/pyrecon/mpi/lib/python3.10/site-packages/pyrecon/recon.py", line 400, in set_los
>     if los in [None, 'local']:
> ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
> 

I have changed the `set_los` function in my branch. Could you take a look and see if this can be merged to the default branch? Thank you.

Xinyi